### PR TITLE
fix: 아트픽셀을 정수 픽셀 그리드에 맞춰 렌더

### DIFF
--- a/src/claudlet/core/creature.py
+++ b/src/claudlet/core/creature.py
@@ -15,8 +15,8 @@ Public API:
     GRID_W, GRID_H : bounding size in art pixels (multiply by u for device px)
 """
 import math
-from PyQt6.QtGui import QColor
-from PyQt6.QtCore import QRectF
+from PyQt6.QtGui import QColor, QPainter
+from PyQt6.QtCore import QRect, QRectF
 
 # autonomous (auto/bypass mode) variants: the pet wears a visor and wanders while
 # it works, each work type keeping its own prop. `autopilot` is the generic cruise.
@@ -99,6 +99,14 @@ HAT_KINDS = ("cap", "hardhat", "beret", "tophat", "propeller", "beanie")
 
 GRID_W, GRID_H = 22, 17   # art-pixel bounding box (incl. room above for props/bounce)
 
+# Rotating a pixel sprite with antialiasing off turns every edge into a
+# staircase (walk leans +-2 degrees, doze 10), so a rotated frame switches
+# antialiasing on for itself alone and flat frames stay hard-edged. This is
+# the angle below which the lean is dropped instead of smoothed: 0 keeps every
+# rotation, because flattening the big ones costs real animation - at 999 doze
+# stops leaning and reads as idle.
+SMOOTH_TILT_DEG = 0.0
+
 PALETTES = {
     "default":      {"body": "#D97757", "hi": "#ECA184", "lo": "#B0532F", "bang": "#D0402E"},
     "shiny_teal":   {"body": "#2FA88C", "hi": "#7FD9C4", "lo": "#1C7361", "bang": "#1F5F52"},
@@ -116,6 +124,39 @@ def palette_colors(palette):
 
 def _sin(frame, period, amp, phase=0.0):
     return math.sin((frame / period + phase) * 2 * math.pi) * amp
+
+
+def _r(v):
+    # half-up, not round(): round() is banker's, sending 4.5 down and 5.5 up -
+    # the half-pixel unevenness this exists to remove
+    return int(math.floor(v + 0.5))
+
+
+def _snap(x, y, w, h):
+    """Art-pixel block -> whole device pixels.
+
+    Antialiasing is off by design, so the rasteriser rounds each QRectF edge on
+    its own and the same art pixel came out 4px wide here and 6px there (the
+    old `w * u + 0.5` padding hid the seams that caused, but not the
+    unevenness). Snapping the origin and rounding the size separately keeps a
+    given art size the same number of pixels wherever it sits. Sizes never
+    reach 0, or thin highlights and the eye dashes vanish at small u.
+    """
+    return _r(x), _r(y), max(1, _r(w)), max(1, _r(h))
+
+
+def _fill(p, x, y, w, h, color):
+    p.fillRect(QRect(*_snap(x, y, w, h)), color)
+
+
+def _snap_offset(dy, u):
+    # bob/baseline_lift shift every block alike, so a fractional value drags the
+    # whole silhouette off the u-grid and its seams crawl as the frame advances
+    return _r(dy * u) / u
+
+
+def _tilt_for(tilt):
+    return 0.0 if abs(tilt) < SMOOTH_TILT_DEG else tilt
 
 
 def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
@@ -342,6 +383,8 @@ def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
         if nod > 0.9:
             prop = "zzz"
 
+    body_dy = _snap_offset(bob + baseline_lift, u)
+
     # arm pose derived from state (arms live on the LEFT/RIGHT sides)
     arm = {"work_computer": "none", "attention": "up", "celebrate": "up",
            "held": "up", "falling": "up", "juggle": "up", "wave": "wave",
@@ -357,10 +400,10 @@ def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
         # apply squash/stretch about body center
         bcx, bcy = 10.5, 9.0
         X = bcx + (col - bcx) * sx
-        Y = bcy + (row - bcy) * sy + bob + baseline_lift
+        Y = bcy + (row - bcy) * sy + body_dy
         W = w * sx
         H = h * sy
-        p.fillRect(QRectF(ox + X * u, oy + Y * u, W * u + 0.5, H * u + 0.5), color)
+        _fill(p, ox + X * u, oy + Y * u, W * u, H * u, color)
 
     # 주머니 빼꼼: 화면에 가로 틈을 내고 고개만 내민 연출. 슬릿 아래는 클립해
     # 안 그려지고(투명), 립/손은 함수 끝에서 틈 위로 덧그린다. 표정/프롭은 현재
@@ -383,7 +426,9 @@ def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
         p.translate(2 * (ox + cx * u), 0)
         p.scale(-1, 1)
     # tilt about creature center
+    tilt = _tilt_for(tilt)
     if tilt:
+        p.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         p.translate(ox + cx * u, oy + 10 * u)
         p.rotate(tilt)
         p.translate(-(ox + cx * u), -(oy + 10 * u))
@@ -532,8 +577,8 @@ def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
 
     # ---- props (screen-ish space, not tilted) ----
     def rect(col, row, w, h, color):
-        Y = row + bob + baseline_lift
-        p.fillRect(QRectF(ox + col * u, oy + Y * u, w * u + 0.5, h * u + 0.5), color)
+        Y = row + body_dy
+        _fill(p, ox + col * u, oy + Y * u, w * u, h * u, color)
 
     from PyQt6.QtCore import Qt
     from PyQt6.QtGui import QFont, QPen, QPainterPath
@@ -572,8 +617,8 @@ def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
         bxx, byy = 17.5, -0.2
         rect(bxx, byy, 3.6, 3.2, WHITE)
         # tail
-        p.fillRect(QRectF(ox + (bxx + 0.4) * u, oy + (byy + 3.0 + bob) * u,
-                          1.0 * u, 1.0 * u), WHITE)
+        _fill(p, ox + (bxx + 0.4) * u, oy + (byy + 3.0 + body_dy) * u,
+              1.0 * u, 1.0 * u, WHITE)
         # bold pixel "!" (stem + dot), centered in the bubble
         ex = bxx + 1.3
         rect(ex, byy + 0.6, 1.0, 1.5, BANG)     # stem
@@ -587,16 +632,16 @@ def draw_creature(p, ox, oy, u, state, frame, facing=1, visor=None, cap=None,
     elif prop == "zzz":
         p.setPen(QPen(ZTXT))
         f = QFont("Sans"); f.setPointSizeF(1.2 * u); f.setBold(True); p.setFont(f)
-        p.drawText(int(ox + 18 * u), int(oy + (4.0 + bob) * u), "z")
+        p.drawText(int(ox + 18 * u), int(oy + (4.0 + body_dy) * u), "z")
         f2 = QFont("Sans"); f2.setPointSizeF(1.8 * u); f2.setBold(True); p.setFont(f2)
-        p.drawText(int(ox + 19.4 * u), int(oy + (2.2 + bob) * u), "Z")
+        p.drawText(int(ox + 19.4 * u), int(oy + (2.2 + body_dy) * u), "Z")
         p.setPen(Qt.PenStyle.NoPen)
     elif prop == "ponder":
         # slow "?" that fades in over the head
         if (frame % 90) > 20:
             p.setPen(QPen(ZTXT)); f = QFont("Sans"); f.setPointSizeF(1.8 * u)
             f.setBold(True); p.setFont(f)
-            p.drawText(int(ox + 18 * u), int(oy + (3.2 + bob) * u), "?")
+            p.drawText(int(ox + 18 * u), int(oy + (3.2 + body_dy) * u), "?")
             p.setPen(Qt.PenStyle.NoPen)
     elif prop == "magnify":
         # a magnifying glass sweeping side to side out front — dark rim for

--- a/src/claudlet/pet.py
+++ b/src/claudlet/pet.py
@@ -62,7 +62,10 @@ PAD_X, PAD_Y = 1, 2                     # padding (art px) around creature for p
 # the pet once the gap exceeds FOLLOW_START, and stops once within FOLLOW_STOP
 # (hysteresis), like a real sidekick trailing along; no facing-based side pick
 # (that made it teleport across when the pet turned).
-COMPANION_U = 2.5                       # companion art-pixel size (half the pet's U=5)
+COMPANION_U = 3                         # companion art-pixel size (pet's U is 5).
+                                        # Integer on purpose: 2.5 split every art
+                                        # pixel 2px/3px, and (GRID_H + 2*PAD_Y)*2.5
+                                        # = 52.5 lost half a pixel to int() below.
 # Follow feel: sets off soon after the pet leaves (short START gap), dawdles at a
 # slow amble while close behind, but SPRINTS when left far behind — the "어?
 # 늦었다!" scramble: speed*(1+gap/FACTOR), capped at speed*CAP.
@@ -228,7 +231,7 @@ class Companion(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
         # purely decorative: never take clicks/focus.
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
-        # COMPANION_U may be fractional (half the pet's U) — window dims are ints
+        # int() is only a guard should COMPANION_U ever go fractional again
         self.w = int((C.GRID_W + 2 * PAD_X) * COMPANION_U)
         self.h = int((C.GRID_H + 2 * PAD_Y) * COMPANION_U)
         self.setFixedSize(self.w, self.h)
@@ -346,7 +349,9 @@ class Companion(QWidget):
     def paintEvent(self, _e):
         p = QPainter(self)
         p.setRenderHint(QPainter.RenderHint.Antialiasing, False)
-        C.draw_creature(p, PAD_X * COMPANION_U, PAD_Y * COMPANION_U,
+        # a fractional origin puts the whole grid between pixels, re-splitting
+        # every art pixel; snapped so a fractional unit can't reintroduce that
+        C.draw_creature(p, round(PAD_X * COMPANION_U), round(PAD_Y * COMPANION_U),
                         COMPANION_U, self._state, self.frame, facing=self.facing,
                         cap=self.hat, gaze=self.gaze)
         p.end()
@@ -2144,8 +2149,10 @@ class Pet(QWidget):
         # facing handled inside draw_creature (body mirrors, text upright)
         if getattr(self, "_in_notch", False):
             u = NOTCH_U
-            ox = (self.w - (C.GRID_W + 2 * PAD_X) * u) / 2 + PAD_X * u
-            oy = (self.h - (C.GRID_H + 2 * PAD_Y) * u) / 2 + PAD_Y * u
+            # centring lands on a half pixel when window and art box differ by
+            # an odd amount, shifting the grid and re-splitting every art pixel
+            ox = round((self.w - (C.GRID_W + 2 * PAD_X) * u) / 2 + PAD_X * u)
+            oy = round((self.h - (C.GRID_H + 2 * PAD_Y) * u) / 2 + PAD_Y * u)
         else:
             u = U
             ox, oy = PAD_X * U, PAD_Y * U

--- a/tests/unit/test_companion_grid.py
+++ b/tests/unit/test_companion_grid.py
@@ -1,0 +1,26 @@
+import sys, os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication
+from claudlet.core import creature as C
+from claudlet import pet as P
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def test_companion_unit_is_whole_pixels():
+    # a fractional unit made every companion art pixel alternate 2px/3px wide
+    assert float(P.COMPANION_U).is_integer(), P.COMPANION_U
+
+
+def test_companion_window_holds_the_whole_sprite():
+    # (GRID_H + 2 * PAD_Y) * 2.5 was 52.5, so int() clipped half a pixel off the
+    # window and the sprite lost its bottom row
+    w = (C.GRID_W + 2 * P.PAD_X) * P.COMPANION_U
+    h = (C.GRID_H + 2 * P.PAD_Y) * P.COMPANION_U
+    assert int(w) == w and int(h) == h, (w, h)
+
+
+def test_companion_draw_origin_is_on_the_grid():
+    assert float(P.PAD_X * P.COMPANION_U).is_integer()
+    assert float(P.PAD_Y * P.COMPANION_U).is_integer()

--- a/tests/unit/test_creature_pixel_grid.py
+++ b/tests/unit/test_creature_pixel_grid.py
@@ -1,0 +1,86 @@
+import sys, os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtGui import QImage, QPainter
+from PyQt6.QtWidgets import QApplication
+from claudlet.core import creature as C
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def test_r_rounds_half_up():
+    assert [C._r(v) for v in (4.5, 5.5, 2.5, 0.5)] == [5, 6, 3, 1]
+    assert [C._r(v) for v in (4.4, 4.6, 0.0)] == [4, 5, 0]
+    assert [C._r(v) for v in (-0.5, -1.5, -1.6)] == [0, -1, -2]
+
+
+def test_snap_size_is_independent_of_position():
+    # the whole point: one art size is one pixel size wherever the block sits
+    sizes = {C._snap(x, x, 5.0, 5.0)[2:] for x in (0.0, 0.1, 0.4, 0.5, 0.9, 12.6, 12.4)}
+    assert sizes == {(5, 5)}
+
+
+def test_snap_puts_origin_on_whole_pixels():
+    x, y, _, _ = C._snap(12.6, 7.4, 4.5, 4.5)
+    assert (x, y) == (13, 7)
+
+
+def test_snap_never_collapses_a_block():
+    # a 0.45-art-pixel highlight at u=2 is 0.9px; rounding it away loses the detail
+    assert C._snap(0.0, 0.0, 0.9, 0.2)[2:] == (1, 1)
+
+
+def test_snap_offset_lands_on_whole_device_pixels():
+    for u in (2, 3, 5, 6):
+        for dy in (0.0, 0.13, 0.5, 0.9, 1.37, -0.6):
+            assert (C._snap_offset(dy, u) * u).is_integer()
+
+
+def test_snap_offset_keeps_whole_pixel_offsets_exact():
+    assert C._snap_offset(1.0, 5) == 1.0
+    assert C._snap_offset(0.0, 5) == 0.0
+
+
+def test_tilt_kept_by_default():
+    assert C.SMOOTH_TILT_DEG == 0.0
+    for t in (-16.0, -2.0, 0.4, 3.0, 10.0):
+        assert C._tilt_for(t) == t
+
+
+def test_tilt_dropped_below_threshold(monkeypatch):
+    monkeypatch.setattr(C, "SMOOTH_TILT_DEG", 5.0)
+    assert C._tilt_for(2.0) == 0.0
+    assert C._tilt_for(-4.9) == 0.0
+    assert C._tilt_for(5.0) == 5.0
+    assert C._tilt_for(-16.0) == -16.0
+
+
+U = 5
+W = (C.GRID_W + 2) * U
+H = (C.GRID_H + 4) * U
+
+
+def _opaque_pixels(state, frame, **kw):
+    img = QImage(W, H, QImage.Format.Format_ARGB32)
+    img.fill(0)
+    p = QPainter(img)
+    p.setRenderHint(QPainter.RenderHint.Antialiasing, False)
+    C.draw_creature(p, U, 2 * U, U, state, frame, **kw)
+    p.end()
+    buf = bytes(img.constBits().asarray(img.sizeInBytes()))
+    return sum(1 for a in buf[3::4] if a > 128)
+
+
+def test_bob_steps_whole_pixels_so_the_silhouette_does_not_breathe():
+    # These states bob but never tilt, so the only thing changing between frames
+    # is the shared vertical offset. A fractional offset re-split every art pixel
+    # and the opaque area wobbled by ~40px; quantised, the area must hold.
+    for state, frames in (("idle", range(0, 34)), ("work_computer", range(0, 30))):
+        areas = {_opaque_pixels(state, f) for f in frames}
+        assert len(areas) == 1, "%s: silhouette area varied %s" % (state, sorted(areas))
+
+
+def test_tilted_frames_still_render_every_state():
+    for state in C.STATES:
+        for frame in (0, 7, 33, 65):
+            assert _opaque_pixels(state, frame) > 0


### PR DESCRIPTION
## 문제

펫 픽셀이 깨져 보입니다. 걷는 중에는 하이라이트 띠와 눈 대시, 다리 테두리가
계단으로 찢어지고, 가만히 있어도 아트픽셀 경계가 프레임마다 기어갑니다.

## 원인 세 가지

**1. 회전 + 안티에일리어싱 off (가장 눈에 띄는 것)**
`walk`는 몸통을 ±2도, `doze`는 10도 회전시킵니다. 픽셀 스프라이트를 AA 없이
회전시키면 모든 테두리가 계단이 됩니다. ±2도는 기울기로 읽히기엔 너무 작고
테두리를 부수기엔 충분한 각도였습니다.

**2. `w * u + 0.5` 패딩**
이음새는 막았지만(실제로 관통 구멍은 0개였습니다) 같은 아트픽셀이 어디선 4px,
어디선 6px로 나오는 문제는 남았습니다.

**3. 소수점 공용 세로 오프셋**
`bob + baseline_lift`는 모든 블록을 같은 값만큼 밉니다. 소수값이면 실루엣 전체가
`u` 그리드를 벗어나고, 프레임이 넘어갈 때마다 아트픽셀이 다시 쪼개져 이음새가
기어갑니다. `jump`/`celebrate`에서 가장 심했습니다.

부수적으로 `COMPANION_U = 2.5`라 컴패니언 아트픽셀이 2px/3px로 번갈아 나왔고,
**같은 소수 단위 때문에 창 높이가 `(GRID_H + 2 * PAD_Y) * 2.5 = 52.5`인데 `int()`가
52로 잘라서 스프라이트 아래가 반픽셀 잘려 있었습니다.** 노치 보관 렌더의 중앙 정렬
원점도 반픽셀에 떨어질 수 있었습니다.

## 수정

`core/creature.py`
- `_r()` — half-up 반올림. `round()`는 banker's라 4.5를 내리고 5.5를 올려서,
  없애려는 반픽셀 불균일을 그대로 만듭니다. 0.9 아트픽셀 하이라이트 띠도 5px에서
  4px로 얇아졌습니다.
- `_snap()` / `_fill()` — 원점은 그리드에 붙이고 크기는 따로 반올림해, 같은 아트
  크기가 어디 있든 같은 픽셀 수가 되게 합니다. 크기는 0으로 내려가지 않습니다
  (작은 `u`에서 얇은 하이라이트와 눈 대시가 사라집니다).
- `_snap_offset()` — 공용 세로 오프셋을 정수 픽셀로 양자화. bob이 픽셀 단위로
  움직입니다.
- `SMOOTH_TILT_DEG` / `_tilt_for()` — 기울어진 프레임에서만 AA를 켭니다. 평평한
  프레임(idle/work 대부분)은 그대로 하드 엣지입니다. 상수는 "매끄럽게 하는 대신
  기울기를 버릴 각도"이고 기본값 0은 전부 유지합니다.

`pet.py`
- `COMPANION_U` 2.5 → 3. 창이 정확히 72x63, 원점이 정확히 (3, 6)이 됩니다.
- 노치 원점, 컴패니언 원점 반올림.

## 검증

`pytest` 556 passed (기존 543 + 신규 13). 변경 전 기준도 543 green이라 회귀 없음.

| | 변경 전 | 변경 후 |
|---|---|---|
| bob 한 주기 불투명 면적 변동 (idle, work_computer) | 42px | **0px** |
| 하이라이트 띠 높이 | 5px | 5px (유지) |
| 1px 관통 이음새 | 0 | 0 |
| 컴패니언 창 | 60x52 (0.5px 잘림) | 72x63 (정확) |

면적 변동 0이 이 PR의 핵심 보증입니다 — 실루엣이 프레임 간에 더 이상 출렁이지
않습니다. 띠 높이 유지는 크기 반올림이 아트를 얇게 만들지 않았다는 확인입니다.

테스트는 AGENTS.md 기준에 맞춰 순수 함수 입출력(`_r`, `_snap`, `_snap_offset`,
`_tilt_for`)과 동작(면적 변동, 창 크기)만 검사합니다. 동작 테스트는 변경 전
코드에서 실패하므로 실제 회귀 가드입니다.

## 판단이 필요한 지점

- **컴패니언이 약 20% 커집니다.** 2.5를 유지하면 반픽셀 그리드가 남고, 2로
  내리면 선명하지만 눈에 띄게 작아집니다. 크기 변화를 원하지 않으시면 3 대신 2로
  바꾸거나 이 커밋만 빼셔도 됩니다.
- `SMOOTH_TILT_DEG` 기본값을 0(전부 회전 유지)으로 뒀습니다. 5.0으로 올리면
  `walk`/`idle`/`thinking`의 미세한 기울기를 버려 더 선명해지지만 그만큼
  움직임이 줄어듭니다. 취향 문제라 상수로 노출만 해뒀습니다.
- 렌더러 아트 좌표 자체가 소수점인 곳이 있습니다(`px(5.4, ..., 0.9, 1.4, ...)`).
  블록 크기와 위치는 이제 일정하지만 아트가 정수 아트픽셀 그리드에 놓인 것은
  아닙니다. 거기까지 맞추려면 스프라이트를 다시 그려야 해서 범위에 넣지 않았습니다.

## 환경

Windows 11 (dpr 1.0, 1920x1080 x2), Python 3.10, PyQt6, claudlet 1.6.0 기준.
Linux/macOS 실기 확인은 못 했습니다. 다만 변경분은 전부 플랫폼 무관한 렌더 좌표
계산이고, 플랫폼 분기 코드는 건드리지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
